### PR TITLE
Handle new feature `set clipboard=unnamedplus`

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -335,7 +335,7 @@ function! s:insert(...) " {{{1
   endif
   "call inputsave()
   let cb_save = &clipboard
-  set clipboard-=unnamed
+  set clipboard-=unnamed clipboard-=unnamedplus
   let reg_save = @@
   call setreg('"',"\r",'v')
   call s:wrapreg('"',char,linemode)
@@ -400,7 +400,7 @@ function! s:dosurround(...) " {{{1
     endif
   endif
   let cb_save = &clipboard
-  set clipboard-=unnamed
+  set clipboard-=unnamed clipboard-=unnamedplus
   let append = ""
   let original = getreg('"')
   let otype = getregtype('"')
@@ -499,7 +499,7 @@ function! s:opfunc(type,...) " {{{1
   let sel_save = &selection
   let &selection = "inclusive"
   let cb_save  = &clipboard
-  set clipboard-=unnamed
+  set clipboard-=unnamed clipboard-=unnamedplus
   let reg_save = getreg(reg)
   let reg_type = getregtype(reg)
   "call setreg(reg,"\n","c")


### PR DESCRIPTION
Hi Tim,

Vim 7.3.074 added the `set clipboard=unnamedplus` feature, which allows use of the X11 clipboard (not PRIMARY) for yank and paste (finally).

https://github.com/b4winckler/vim/commit/38b368ba4d42f758a0497cb756327076b35def45

This is just a trivial update patch to work with this new feature.

Thanks,
Sung (a big fan)
