### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When used as a git submodule with pathogen, `doc/tags` is created and causes `git status` to show the submodule as dirty. This should fix that.
