### PR TITLE
Add dictionary for user can add custom mapping rule.

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -629,7 +629,7 @@ function! s:surround_custom_map(scope) "{{{
     if (a:scope != 'g') && empty(&ft)
         return
     endif
-    let map_dict =  a:scope == 'g' ? 'global' : &ft
+    let map_dict =  a:scope == 'g' ? '_' : &ft
 
     if !has_key(g:surround_custom_mapping, map_dict)
         return


### PR DESCRIPTION
introduce g:surround_custom_mapping dictionary which help filetype based custom mapping.

I hope this mini utility for surround.vim is bundled in orignal surround.vim.
User can easily add custom mapping rule for each `&filetype` or global scope based.
## configuration example

```
let g:surround_custom_mapping = {}"{{{
let g:surround_custom_mapping._ = {
            \ 'p':  "<pre> \r </pre>",
            \ 'w':  "%w(\r)",
            \ }
let g:surround_custom_mapping.help = {
            \ 'p':  "> \r <",
            \ }
let g:surround_custom_mapping.ruby = {
            \ '-':  "<% \r %>",
            \ '=':  "<%= \r %>",
            \ '9':  "(\r)",
            \ '5':  "%(\r)",
            \ '%':  "%(\r)",
            \ 'w':  "%w(\r)",
            \ '#':  "#{\r}",
            \ '3':  "#{\r}",
            \ 'e':  "begin \r end",
            \ 'E':  "<<EOS \r EOS",
            \ 'i':  "if \1if\1 \r end",
            \ 'u':  "unless \1unless\1 \r end",
            \ 'c':  "class \1class\1 \r end",
            \ 'm':  "module \1module\1 \r end",
            \ 'd':  "def \1def\1\2args\r..*\r(&)\2 \r end",
            \ 'p':  "\1method\1 do \2args\r..*\r|&| \2\r end",
            \ 'P':  "\1method\1 {\2args\r..*\r|&|\2 \r }",
            \ }
let g:surround_custom_mapping.javascript = {
            \ 'f':  "function(){ \r }"
            \ }
let g:surround_custom_mapping.lua = {
            \ 'f':  "function(){ \r }"
            \ }
let g:surround_custom_mapping.python = {
            \ 'p':  "print( \r)",
            \ '[':  "[\r]",
            \ }
let g:surround_custom_mapping.vim= {
            \'f':  "function! \r endfunction"
            \ }
```
