### PR TITLE
doc: more "s" to "S" in visual mode, and fix a typo

### DIFF
--- a/doc/surround.txt
+++ b/doc/surround.txt
@@ -73,7 +73,7 @@ mode, each line is surrounded.
 
 A "gS" in visual mode, known as *vgS* , behaves similarly.  In linewise visual
 mode, the automatic indenting is suppressed.  In blockwise visual mode, this
-enables surrounding past the end of the like with 'virtualedit' set (there
+enables surrounding past the end of the line with 'virtualedit' set (there
 seems to be no way in Vim Script to differentiate between a jagged end of line
 selection and a virtual block selected past the end of the line, so two maps
 were needed).


### PR DESCRIPTION
I found a few more mentions of using `s` while in visual mode. The first commit changes them to the supported `S` mapping.

The second commit fixes a stray typo I found: “like” for “line”.

I used two commits since the changes are logically separate, but I can squash them if you would like that better.
