### PR TITLE
Make repeat work for HTML tags

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -435,7 +435,7 @@ function! s:dosurround(...) " {{{1
   if newchar == ""
     silent! call repeat#set("\<Plug>Dsurround".char,scount)
   else
-    silent! call repeat#set("\<Plug>Csurround".char.newchar,scount)
+    silent! call repeat#set("\<Plug>Csurround".char.newchar.s:tag,scount)
   endif
 endfunction " }}}1
 


### PR DESCRIPTION
Modify repeat#set for Csurround and Yssurround.  
Clear s:tag to prevent bug where > is injected for non-html repeats
