### PR TITLE
Support to set surround_no_mappings individually for each mode

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -567,11 +567,13 @@ if !exists("g:surround_no_mappings") || ! g:surround_no_mappings
   nmap ySS <Plug>YSsurround
   xmap S   <Plug>VSurround
   xmap gS  <Plug>VgSurround
-  if !hasmapto("<Plug>Isurround","i") && "" == mapcheck("<C-S>","i")
-    imap    <C-S> <Plug>Isurround
+  if !exists("g:surround_no_insert_mappings") || ! g:surround_no_insert_mappings
+    if !hasmapto("<Plug>Isurround","i") && "" == mapcheck("<C-S>","i")
+      imap    <C-S> <Plug>Isurround
+    endif
+    imap      <C-G>s <Plug>Isurround
+    imap      <C-G>S <Plug>ISurround
   endif
-  imap      <C-G>s <Plug>Isurround
-  imap      <C-G>S <Plug>ISurround
 endif
 
 " vim:set ft=vim sw=2 sts=2 et:


### PR DESCRIPTION
If disable mappings in all mode.

``` vim
let g:surround_no_mappings = 1 " It is the same as the former. 
```

If disable mappings only in normal mode.

``` vim
let g:surround_no_nmappings = 1
```

If disable mappings only in visual mode.

``` vim
let g:surround_no_xmappings = 1
```

If disable mappings only in insert mode.

``` vim
let g:surround_no_imappings = 1
```
