### PR TITLE
Added support to surround Ruby Blocks if, class, module, while, for, etc...

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -224,6 +224,12 @@ function! s:wrap(string,char,type,...)
         let after = ' ' . after
       endif
     endif
+  elseif newchar ==# "R" || newchar == "\<C-R>"
+    let blk = input('block: ')
+    if blk != ""
+      let before = blk . "\n\t"
+      let after = "\nend"
+    endif
   elseif newchar ==# "\<C-F>"
     let fnc = input('function: ')
     let before = '('.fnc.' '


### PR DESCRIPTION
Use 'R' or '<C-R>' to trigger addition of a ruby block around the
selected object either in visual mode or while using with ys commands.

TODO: Need to add support to allow deletion (via ds) of a ruby block.
