### PR TITLE
Added an option 'o' for setting custom surround

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -236,6 +236,11 @@ function! s:wrap(string,char,type,...)
   elseif newchar == "\<C-[>" || newchar == "\<C-]>"
     let before = "{\n\t"
     let after  = "\n}"
+  elseif newchar ==# 'o'
+    let replacement = substitute(input(">> "),"\\\\r","\r", '')
+    let all    = s:process(replacement)
+    let before = s:extractbefore(all)
+    let after  =  s:extractafter(all)
   elseif newchar !~ '\a'
     let before = newchar
     let after  = newchar


### PR DESCRIPTION
It is sometimes nice to be able to just type in the expression rather
then prepare it ahead of the time.

Say if you want to refactor the code for which you do not have support.
Or say you are editing github markdown and you want to encapsulate
the code in ``` tags. With this you can simply do the following:

```
class test
    def initialise

    end
end
```

Select the text then:

```
gSo` ` `ruby\r` ` ` (I added spaces so that github does not covert them)
```

```
` ` ` ruby
class test
    def initialise

    end
end
` ` `
```
