### PR TITLE
Handle arbitrary delimiters with cs and ds

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -379,6 +379,12 @@ function! s:dosurround(...) " {{{1
   let strcount = (scount == 1 ? "" : scount)
   if char == '/'
     exe 'norm! '.strcount.'[/d'.strcount.']/'
+  elseif char =~# '[[:punct:]]' && char !~# '[][(){}<>]'
+    exe 'norm! T'.char
+    if getline('.')[col('.')-1] == char
+      exe 'norm! l'
+    endif
+    exe 'norm! dt'.char
   else
     exe 'norm! d'.strcount.'i'.char
   endif
@@ -403,6 +409,9 @@ function! s:dosurround(...) " {{{1
     norm! "_x
     call setreg('"','/**/',"c")
     let keeper = substitute(substitute(keeper,'^/\*\s\=','',''),'\s\=\*$','','')
+  elseif char =~# '[[:punct:]]' && char !~# '[][(){}<>]'
+    exe 'norm! F'.char
+    exe 'norm! df'.char
   else
     " One character backwards
     call search('.','bW')


### PR DESCRIPTION
Resolves #105 by adding flexibility such that cs/ds can change/remove any arbitrary surrounding character, rather than just the usual text object delimiters and html tags &c.
