### PR TITLE
Add surrounding function name delete/change

### DIFF
--- a/doc/surround.txt
+++ b/doc/surround.txt
@@ -114,6 +114,10 @@ slight shortcut for ysi (cswb == ysiwb, more or less).
 A p represents a |paragraph|.  This behaves similarly to w, W, and s above;
 however, newlines are sometimes added and/or removed.
 
+An f represents a function call.  A function call consists of an identifier
+followed by a parenthesized expression.  See |isident| for details on
+identifiers.
+
 REPLACEMENTS                                    *surround-replacements*
 
 A replacement argument is a single character, and is required by |cs|, |ys|,
@@ -135,6 +139,10 @@ by themselves.
 
 If s is used, a leading but not trailing space is added.  This is useful for
 removing parentheses from a function call with csbs.
+
+If f is used, Vim prompts for a function name to insert.  If F is used, the
+expression is surrounded by additional whitespace.  If <C-F> is used, the
+function name will be place in the parenthesis, Lisp-style.
 
 CUSTOMIZING                                     *surround-customizing*
 

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -385,6 +385,16 @@ function! s:dosurround(...) " {{{1
       exe 'norm! l'
     endif
     exe 'norm! dt'.char
+  elseif char =~# '[fF]'
+    let [sfline,sfcol,mfline,mfcol,efline,efcol] = [0,0,0,0,0,0]
+    for i in range(scount) 
+      let [sfline,sfcol,mfline,mfcol,efline,efcol] = s:searchfuncpos()
+      call cursor(sfline, sfcol)
+    endfor
+    if sfline != 0
+      call cursor(mfline, mfcol)
+      norm! di(
+    endif
   else
     exe 'norm! d'.strcount.'i'.char
   endif
@@ -412,6 +422,9 @@ function! s:dosurround(...) " {{{1
   elseif char =~# '[[:punct:]]' && char !~# '[][(){}<>]'
     exe 'norm! F'.char
     exe 'norm! df'.char
+  elseif char =~# '[fF]'
+    call cursor(sfline, sfcol)
+    norm! df)
   else
     " One character backwards
     call search('.','bW')
@@ -422,7 +435,7 @@ function! s:dosurround(...) " {{{1
   let oldhead = strpart(oldline,0,strlen(oldline)-strlen(rem2))
   let oldtail = strpart(oldline,  strlen(oldline)-strlen(rem2))
   let regtype = getregtype('"')
-  if char =~# '[\[({<T]' || spc
+  if char =~# '[\[({<TF]' || spc
     let keeper = substitute(keeper,'^\s\+','','')
     let keeper = substitute(keeper,'\s\+$','','')
   endif
@@ -551,6 +564,48 @@ function! s:closematch(str) " {{{1
   else
     return ""
   endif
+endfunction " }}}1
+
+function! s:searchfuncpos() " {{{1
+  " Save cursor position and last visual mode
+  let ppos = getpos(".")
+  let svpos = getpos("'<")
+  let evpos = getpos("'>")
+  let pvmode = visualmode()
+
+  let [sfline,sfcol,mfline,mfcol,efline,efcol] = [0,0,0,0,0,0]
+  while 1
+    " Get surounding paren text object
+    norm! va(
+    let [ebuf,eline,ecol,eoff] = getpos(".")
+    let [sbuf,sline,scol,soff] = getpos("v")
+    execute "norm! \<esc>"
+
+    if eline == sline && ecol == scol
+      break
+    endif
+
+    call cursor(sline,scol,soff)
+    let [fline,fcol] = searchpos('\i\+\s*(','bnec')
+    if fline == sline && fcol == scol
+      let [sfline,sfcol] = searchpos('\i\+\s*(','bnc')
+      let [mfline,mfcol] = [sline,scol]
+      let [efline,efcol] = [eline,ecol]
+      break
+    elseif fline == 0 && fcol == 0
+      break
+    else
+      norm! h
+    endif
+  endwhile
+
+  " Reset cursor position and last visual mode
+  call setpos(".",ppos)
+  call setpos("'<",svpos)
+  call setpos("'>",evpos)
+  call visualmode(pvmode)
+
+  return [sfline,sfcol,mfline,mfcol,efline,efcol]
 endfunction " }}}1
 
 nnoremap <silent> <Plug>SurroundRepeat .


### PR DESCRIPTION
Adds `f`/`F` support to `s:dosurround`, to allow changing/deleting the name of a surrounding function call. As with `t`, `f` preserves whitespace while `F` removes it. For example,

```
Old text                  Command      New text
func(arg1, ar*g2)         dsf          arg1, arg2
func(  arg1, ar*g2  )     csf)         (  arg1, arg2  )
func(  arg1, ar*g2  )     csF)         (arg1, arg2)
```
