### PR TITLE
Add repeat.vim support to surround with LaTeX environment 'ys<>l'

### DIFF
--- a/doc/surround.txt
+++ b/doc/surround.txt
@@ -115,6 +115,10 @@ slight shortcut for ysi (cswb == ysiwb, more or less).
 A p represents a |paragraph|.  This behaves similarly to w, W, and s above;
 however, newlines are sometimes added and/or removed.
 
+An f represents a function call.  A function call consists of an identifier
+followed by a parenthesized expression.  See |isident| for details on
+identifiers.
+
 REPLACEMENTS                                    *surround-replacements*
 
 A replacement argument is a single character, and is required by |cs|, |ys|,
@@ -137,6 +141,10 @@ themselves.
 
 If s is used, a leading but not trailing space is added.  This is useful for
 removing parentheses from a function call with csbs.
+
+If f is used, Vim prompts for a function name to insert.  If F is used, the
+expression is surrounded by additional whitespace.  If <C-F> is used, the
+function name will be place in the parenthesis, Lisp-style.
 
 CUSTOMIZING                                     *surround-customizing*
 

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -212,10 +212,11 @@ function! s:wrap(string,char,type,removed,special)
   elseif newchar ==# 'l' || newchar == '\'
     " LaTeX
     let env = input('\begin{')
-    let env = '{' . env
-    let env .= s:closematch(env)
-    echo '\begin'.env
     if env != ""
+      let s:input = env."\<CR>"
+      let env = '{' . env
+      let env .= s:closematch(env)
+      echo '\begin'.env
       let before = '\begin'.env
       let after  = '\end'.matchstr(env,'[^}]*').'}'
     endif

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -392,6 +392,16 @@ function! s:dosurround(...) " {{{1
       exe 'norm! l'
     endif
     exe 'norm! dt'.char
+  elseif char =~# '[fF]'
+    let [sfline,sfcol,mfline,mfcol,efline,efcol] = [0,0,0,0,0,0]
+    for i in range(scount) 
+      let [sfline,sfcol,mfline,mfcol,efline,efcol] = s:searchfuncpos()
+      call cursor(sfline, sfcol)
+    endfor
+    if sfline != 0
+      call cursor(mfline, mfcol)
+      norm! di(
+    endif
   else
     exe 'norm! d'.strcount.'i'.char
   endif
@@ -419,6 +429,9 @@ function! s:dosurround(...) " {{{1
   elseif char =~# '[[:punct:]]' && char !~# '[][(){}<>]'
     exe 'norm! F'.char
     exe 'norm! df'.char
+  elseif char =~# '[fF]'
+    call cursor(sfline, sfcol)
+    norm! df)
   else
     " One character backwards
     call search('\m.', 'bW')
@@ -429,7 +442,7 @@ function! s:dosurround(...) " {{{1
   let oldhead = strpart(oldline,0,strlen(oldline)-strlen(rem2))
   let oldtail = strpart(oldline,  strlen(oldline)-strlen(rem2))
   let regtype = getregtype('"')
-  if char =~# '[\[({<T]' || spc
+  if char =~# '[\[({<TF]' || spc
     let keeper = substitute(keeper,'^\s\+','','')
     let keeper = substitute(keeper,'\s\+$','','')
   endif
@@ -559,6 +572,48 @@ function! s:closematch(str) " {{{1
   else
     return ""
   endif
+endfunction " }}}1
+
+function! s:searchfuncpos() " {{{1
+  " Save cursor position and last visual mode
+  let ppos = getpos(".")
+  let svpos = getpos("'<")
+  let evpos = getpos("'>")
+  let pvmode = visualmode()
+
+  let [sfline,sfcol,mfline,mfcol,efline,efcol] = [0,0,0,0,0,0]
+  while 1
+    " Get surounding paren text object
+    norm! va(
+    let [ebuf,eline,ecol,eoff] = getpos(".")
+    let [sbuf,sline,scol,soff] = getpos("v")
+    execute "norm! \<esc>"
+
+    if eline == sline && ecol == scol
+      break
+    endif
+
+    call cursor(sline,scol,soff)
+    let [fline,fcol] = searchpos('\i\+\s*(','bnec')
+    if fline == sline && fcol == scol
+      let [sfline,sfcol] = searchpos('\i\+\s*(','bnc')
+      let [mfline,mfcol] = [sline,scol]
+      let [efline,efcol] = [eline,ecol]
+      break
+    elseif fline == 0 && fcol == 0
+      break
+    else
+      norm! h
+    endif
+  endwhile
+
+  " Reset cursor position and last visual mode
+  call setpos(".",ppos)
+  call setpos("'<",svpos)
+  call setpos("'>",evpos)
+  call visualmode(pvmode)
+
+  return [sfline,sfcol,mfline,mfcol,efline,efcol]
 endfunction " }}}1
 
 nnoremap <silent> <Plug>SurroundRepeat .


### PR DESCRIPTION
A patch for repeat `ys<motion/object>l` #152 
Uses `s:input` of patch #125

Patch refers only to commit  605c12d with changes in one file. I just pulled changes from someone else in my fork and they popped up here in this pull request. Sorry, I should have created a branch. (Was my first pull request.)