### PR TITLE
Add repeat.vim support to surround with LaTeX environment 'ys<>l'

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -212,10 +212,11 @@ function! s:wrap(string,char,type,removed,special)
   elseif newchar ==# 'l' || newchar == '\'
     " LaTeX
     let env = input('\begin{')
-    let env = '{' . env
-    let env .= s:closematch(env)
-    echo '\begin'.env
     if env != ""
+      let s:input = env."\<CR>"
+      let env = '{' . env
+      let env .= s:closematch(env)
+      echo '\begin'.env
       let before = '\begin'.env
       let after  = '\end'.matchstr(env,'[^}]*').'}'
     endif


### PR DESCRIPTION
A patch for repeat ys<motion/object>l #152 
Uses s:input of patch #125