### PR TITLE
check &ft for ft-specific surrounding

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -164,7 +164,8 @@ function! s:wrap(string,char,type,removed,special)
   elseif newchar ==# ':'
     let before = ':'
     let after = ''
-  elseif newchar =~# "[tT\<C-T><,]"
+  elseif &ft =~# '^html\|htm\|xml\|xhtml$' && newchar =~# "[tT\<C-T><,]"
+    " html tag <>
     let dounmapp = 0
     let dounmapb = 0
     if !maparg(">","c")
@@ -209,7 +210,7 @@ function! s:wrap(string,char,type,removed,special)
         endif
       endif
     endif
-  elseif newchar ==# 'l' || newchar == '\'
+  elseif &ft =~# '^latex|tex$' && newchar ==# 'l' || newchar == '\'
     " LaTeX
     let env = input('\begin{')
     if env != ""


### PR DESCRIPTION
for example `t`, `T`, `<C-T>`, and `,` for inserting surrounded tag should be enabled only with html-similar file types, and `l` and `\` for inserting surrounded tex directive only with latex or tex.

This will fix #159, partially unless the using of `,` is justified