### PR TITLE
Don't block use of user defined text objects

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -407,7 +407,7 @@ function! s:dosurround(...) " {{{1
     endif
     exe 'norm! dt'.char
   else
-    exe 'norm! d'.strcount.'i'.char
+    exe 'norm d'.strcount.'i'.char
   endif
   let keeper = getreg('"')
   let okeeper = keeper " for reindent below
@@ -436,7 +436,7 @@ function! s:dosurround(...) " {{{1
   else
     " One character backwards
     call search('\m.', 'bW')
-    exe "norm! da".char
+    exe "norm da".char
   endif
   let removed = getreg('"')
   let rem2 = substitute(removed,'\n.*','','')
@@ -510,7 +510,7 @@ function! s:opfunc(type, ...) abort " {{{1
   let reg_type = getregtype(reg)
   let type = a:type
   if a:type == "char"
-    silent exe 'norm! v`[o`]"'.reg.'y'
+    silent exe 'norm v`[o`]"'.reg.'y'
     let type = 'v'
   elseif a:type == "line"
     silent exe 'norm! `[V`]"'.reg.'y'


### PR DESCRIPTION
I don't know if this is the _right_ solution because there may be ramifications to allowing mappings through  here, but this change solves the problem I was having, fixing #199. With these changes and the text objects I have setup such as `q` for curly double quotes and `Q` for curly single quotes, I can dow do things like:
- `Change “double̝ quotes” to single` with `csqQ` → `Change ‘double quotes’ to single`
- `Change “double̝ quotes” to star` with `csq*`→ `Change *double quotes* to star`
- `Change (in̝ parenthesis) to quotes` with `cs(q`→ `Change “in parenthesis” to quotes`

These (along with things like `dsq` to delete surrounding quotes) were ignored before even if the surround mapping AND text object existed.

By contrast the solution presented in #107 only works for arbitrary single characters where the left and right side of the surround use the same character and the 'surround target' character is an exact match for the one being searched for. It doesn't work for more complex surround objects such as mixed matched pairs that have special text objects.
