### PR TITLE
Fix s:inputtarget() cancellation on <Esc> or <C-C>

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -26,7 +26,7 @@ function! s:inputtarget()
   if c == " "
     let c .= s:getchar()
   endif
-  if c =~ "\<Esc>\|\<C-C>\|\0"
+  if c =~ "\<Esc>" || c =~ "\<C-C>"
     return ""
   else
     return c


### PR DESCRIPTION
There was a bug that prevented canceling `changesurround`, caused by an unescaped backslash in a regex string. I changed this to multiple regex matches instead of a single match for a pattern with branches.

Additionally there was a test for `c =~ "\0"` which always succeeds so I removed it, although I don't understand why it was there in the first place. In case it was meant to test for an empty string, removing the test does not affect the return value.