### PR TITLE
Fix blankline

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -263,11 +263,16 @@ function! s:wrap(string,char,type,removed,special)
     elseif keeper =~ '\n$' && after =~ '^\n'
       let after = strpart(after,1)
     endif
-    if before !~ '\n\s*$'
+    if keeper !~ '^\n' && before !~ '\n\s*$'
       let before .= "\n"
       if a:special
         let before .= "\t"
       endif
+    elseif keeper =~ '^\n' && before =~ '\n\s*$'
+      let keeper = strcharpart(keeper,1)
+    endif
+    if type ==# 'V' && keeper =~ '\n\s*\n$'
+      let keeper = strcharpart(keeper,0,strchars(keeper) - 1)
     endif
   endif
   if type ==# 'V'


### PR DESCRIPTION
Fix not to add `<CR>` to `before` when `keeper` preceded by `<CR>` and to remove `<CR>` when both has one,  just like `after`.
Remove extra `<CR>` which appears when regtype "V".