### PR TITLE
Fix empty text object when changing surrounding

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -402,11 +402,6 @@ function! s:dosurround(...) " {{{1
   endif
   let keeper = getreg('"')
   let okeeper = keeper " for reindent below
-  if keeper == ""
-    call setreg('"',original,otype)
-    let &clipboard = cb_save
-    return ""
-  endif
   let oldline = getline('.')
   let oldlnum = line('.')
   if char ==# "p"


### PR DESCRIPTION
Hi @tpope,

I also met problems like #261. After digging into the plugin code, I find out it's caused by some lines of codes that check if keeper is empty. So I just delete them, and it works. I cannot figure out why you directly return when keeper is empty. Is that because when keeper is empty, there is nothing to be done, and you want it to finish execution early? But cases like `<div></div>` cst<p, `""` cs"' will not work.