### PR TITLE
Add a pairs mapping for double quotes

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -137,7 +137,7 @@ function! s:wrap(string,char,type,removed,special)
   else
     let initspaces = matchstr(getline('.'),'\%^\s*')
   endif
-  let pairs = "b()B{}r[]a<>"
+  let pairs = 'b()B{}r[]a<>q""'
   let extraspace = ""
   if newchar =~ '^ '
     let newchar = strpart(newchar,1)


### PR DESCRIPTION
Surround with double quotes without holding the shift key.