### PR TITLE
Add handling of C-style comments

### DIFF
--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -164,6 +164,9 @@ function! s:wrap(string,char,type,removed,special)
   elseif newchar ==# ':'
     let before = ':'
     let after = ''
+  elseif newchar ==# 'c'
+    let before = '/*'
+    let after = '*/'
   elseif newchar =~# "[tT\<C-T><]"
     let dounmapp = 0
     let dounmapb = 0


### PR DESCRIPTION
I didn't even know they were C-style comments and not C++ comments, but [cppreference says so](https://en.cppreference.com/w/cpp/comment).

However, I think this can be useful.