### PR TITLE
Add reference in Readme to detailed documentation at surround.txt

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,6 +60,10 @@ and removing pairs of tags simultaneously is a breeze.
 The `.` command will work with `ds`, `cs`, and `yss` if you install
 [repeat.vim](https://github.com/tpope/vim-repeat).
 
+## Documentation
+
+You can find comprehensive [docs here](https://github.com/tpope/vim-surround/blob/master/doc/surround.txt).
+
 ## Installation
 
 Install using your favorite package manager, or use Vim's built-in package


### PR DESCRIPTION
Fixes #321 

There's no reference to comprehensive documentation in the Readme.md which must be an oversight. It took me far too long to find the documentation, as a result. Google didn't help either.

The documentation is great, can't see why one wouldn't point to it. Thanks for the amazing plugin!