### PR TITLE
Add Counts for Replacment Arguments

### DIFF
--- a/doc/surround.txt
+++ b/doc/surround.txt
@@ -129,6 +129,12 @@ b, B, r, and a are aliases for ), }, ], and >.  To fulfill the common need for
 code blocks in C-style languages, <C-}> (which is really <C-]>) adds braces on
 lines separate from the content.
 
+If a number is used, the remaining replacement argument is multiplied by that
+count.
+
+  Old text                  Command           New text ~
+  hello                     ysW2*             **hello**
+
 If t or < is used, Vim prompts for an HTML/XML tag to insert.  You may specify
 attributes here and they will be stripped from the closing tag. If replacing a
 tag, its attributes are kept in the new tag. End your input with > to discard

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -35,7 +35,7 @@ endfunction
 
 function! s:inputreplacement()
   let c = s:getchar()
-  if c == " "
+  if c =~ "[ 0-9]"
     let c .= s:getchar()
   endif
   if c =~ "\<Esc>" || c =~ "\<C-C>"
@@ -164,6 +164,11 @@ function! s:wrap(string,char,type,removed,special)
   elseif newchar ==# ':'
     let before = ':'
     let after = ''
+  elseif newchar =~ '^[0-9].'
+    let scount = strpart(newchar,0,1)
+    let newchar = strpart(newchar,1)
+    let before = repeat(newchar, scount)
+    let after = repeat(newchar, scount)
   elseif newchar =~# "[tT\<C-T><]"
     let dounmapp = 0
     let dounmapb = 0

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -139,6 +139,11 @@ function! s:wrap(string,char,type,removed,special)
   endif
   let pairs = "b()B{}r[]a<>"
   let extraspace = ""
+  let scount = 1
+  if newchar =~ '^[0-9]'
+    let scount = strpart(newchar,0,1)
+    let newchar = strpart(newchar,1)
+  endif
   if newchar =~ '^ '
     let newchar = strpart(newchar,1)
     let extraspace = ' '
@@ -164,11 +169,6 @@ function! s:wrap(string,char,type,removed,special)
   elseif newchar ==# ':'
     let before = ':'
     let after = ''
-  elseif newchar =~ '^[0-9].'
-    let scount = strpart(newchar,0,1)
-    let newchar = strpart(newchar,1)
-    let before = repeat(newchar, scount)
-    let after = repeat(newchar, scount)
   elseif newchar =~# "[tT\<C-T><]"
     let dounmapp = 0
     let dounmapb = 0
@@ -256,6 +256,8 @@ function! s:wrap(string,char,type,removed,special)
     let before = ''
     let after  = ''
   endif
+  let before = repeat(before, scount)
+  let after = repeat(after, scount)
   let after  = substitute(after ,'\n','\n'.initspaces,'g')
   if type ==# 'V' || (a:special && type ==# "v")
     let before = substitute(before,' \+$','','')


### PR DESCRIPTION
This PR adds support for repeating replacement arguments by beginning the argument with a count.

Examples:
```
  Old text            Command           New text
  hello               ysW2*             **hello**
  hello               ysW2]             [[hello]]
```

Repeated delimeters are used by markdown a lot as well as some other languages. Many of the posed use cases of #97 involve repeated delimeters and I think this PR is a more intuitive way to support them.