### PR TITLE
Introduce configuration option to disable adding spaces

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,6 +77,9 @@ support:
 Only the opening brackets—`[`, `{`, and `(`—add a space.  Use a closing
 bracket, or the `b` (`(`) and `B` (`{`) aliases.
 
+Alternatively, to _completely disable_ adding of spaces (even with opening
+brackets) - then one may set `let g:surround_insert_space = 0`.
+
 ## Contributing
 
 See the contribution guidelines for

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -7,6 +7,7 @@ if exists("g:loaded_surround") || &cp || v:version < 700
   finish
 endif
 let g:loaded_surround = 1
+let g:surround_insert_space = get(g:, 'surround_insert_space', 1)
 
 " Input functions {{{1
 
@@ -237,7 +238,7 @@ function! s:wrap(string,char,type,removed,special)
     let before = '('.fnc.' '
     let after = ')'
   elseif idx >= 0
-    let spc = (idx % 3) == 1 ? " " : ""
+    let spc = (idx % 3) == 1 && g:surround_insert_space ? " " : ""
     let idx = idx / 3 * 3
     let before = strpart(pairs,idx+1,1) . spc
     let after  = spc . strpart(pairs,idx+2,1)


### PR DESCRIPTION
Although I'm familiar with the possibility of using _closing_ brackets ([as was added](https://github.com/tpope/vim-surround/commit/3d188ed2113431cf8dac77be61b842acb64433d9) to [the FAQ](https://github.com/tpope/vim-surround#faq)) to prevent adding spaces - I personally have no use cases that require such spaces, and reaching further (to the closing bracket) is less comfortable - thus I'd like the option to disable this feature entirely.

For this I have added a configuration option to disable/disclude such spaces like so:
```vim
let g:surround_insert_space = 0
```
(the default value will remain `1`, so as not to break existing/expected behavior)

It's safe to assume that for such a common issue (https://github.com/tpope/vim-surround/issues/366, https://github.com/tpope/vim-surround/issues/363, https://github.com/tpope/vim-surround/issues/314, https://github.com/tpope/vim-surround/issues/303, https://github.com/tpope/vim-surround/issues/240, https://github.com/tpope/vim-surround/issues/205, https://github.com/tpope/vim-surround/issues/108, https://github.com/tpope/vim-surround/issues/27
...), at least some of these other users could benefit from such a feature.