### PR TITLE
Add an option to insert function names in insert mode

### DIFF
--- a/doc/surround.txt
+++ b/doc/surround.txt
@@ -148,6 +148,12 @@ function name inside the parentheses.
 If s is used, a leading but not trailing space is added.  This is useful for
 removing parentheses from a function call with csbs.
 
+If you prefer entering function name inside the buffer (possibly with a help
+from lsp completion). You can enable this behaviour with an option.
+>
+  let g:surround_insert_func_name_interactivly = "1"
+<
+
 CUSTOMIZING                                     *surround-customizing*
 
 The following adds a potential replacement on "-" (ASCII 45) in PHP files.

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -221,15 +221,25 @@ function! s:wrap(string,char,type,removed,special)
       let after  = '\end'.matchstr(env,'[^}]*').'}'
     endif
   elseif newchar ==# 'f' || newchar ==# 'F'
-    let fnc = input('function: ')
-    if fnc != ""
-      let s:input = fnc."\<CR>"
-      let before = substitute(fnc,'($','','').'('
+    if !exists("g:surround_insert_func_name_interactivly")
+      let fnc = input('function: ')
+      if fnc != ""
+        let s:input = fnc."\<CR>"
+        let before = substitute(fnc,'($','','').'('
+        let after  = ')'
+        if newchar ==# 'F'
+          let before .= ' '
+          let after = ' ' . after
+        endif
+      endif
+    else
+      let before = '('
       let after  = ')'
       if newchar ==# 'F'
         let before .= ' '
         let after = ' ' . after
       endif
+      startinsert
     endif
   elseif newchar ==# "\<C-F>"
     let fnc = input('function: ')


### PR DESCRIPTION
By default Surround prompts for a function name using input(), which interrupts the flow, and lacks lsp completion.

This pr adds an option to change this behavior - instead of using prompt(), user enters insert mode, where all buffer completion is available to them.